### PR TITLE
prevent triangleSimulation binary from being checked in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ core*
 rof_tables*
 callgrind*
 serial-borg-moea
-
+./triangleSimulation
 
 #
 # Editor files


### PR DESCRIPTION
I assume we don't want this checked in since it may be compiled in different ways for different architectures.